### PR TITLE
chore(deps): replace Renovate with Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":disableDependencyDashboard",
-    ":semanticCommitTypeAll(fix)"
-  ],
-  "assigneesFromCodeOwners": true
-}


### PR DESCRIPTION
Please include a summary of the changes. **What** has changed and **why**?.

This replaces the repository's Renovate setup with Dependabot so dependency updates are managed with the GitHub-native tool used elsewhere in the org.

It removes `.github/renovate.json` and adds `.github/dependabot.yaml` with daily update checks for the two dependency ecosystems in this repo: Go modules and GitHub Actions. The Dependabot config keeps cooldown windows aligned with the org convention and uses Dependabot's default commit message behavior.

Fixes N/A

## Type of change

- [x] 🧹 Refactor
- [ ] 🪲 Bug fix
- [ ] 🚀 New feature
- [ ] ⛓️‍💥 Breaking change
- [ ] 📚 Documentation update