### PR TITLE
ci: add CI workflow with Required Checks aggregation job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+---
+name: CI
+
+on:
+  pull_request:
+  merge_group:
+
+permissions: {}
+
+jobs:
+  required-checks:
+    name: CI - Required Checks
+    if: always()
+    runs-on: ubuntu-latest
+    # needs: []
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: ✅ All required checks passed
+        run: echo "All required checks passed."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,5 +19,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: ✅ All required checks passed
-        run: echo "All required checks passed."
+      - name: ✅ Require checks in PR
+        uses: devantler-tech/actions/require-checks-in-pr@1f66c91d45d374ceac9fe830a783444ebc9be958 # v3.2.0
+        with:
+          job-results: ""


### PR DESCRIPTION
## Summary

Add a CI workflow with a `CI - Required Checks` aggregation job to satisfy the org-wide ruleset requiring this status check on PRs.

## Changes

- **`.github/workflows/ci.yaml`** — New workflow triggered on `pull_request` and `merge_group` with a single `CI - Required Checks` job using the `devantler-tech/actions/require-checks-in-pr` composite action (v3.2.0). The job currently has no dependencies — future checks added to this workflow can be wired as `needs`.

## Notes

- Reusable workflows (validate-go-project, scan-for-workflow-vulnerabilities, enable-auto-merge) are handled via org-level custom properties and are not called from this workflow.