### PR TITLE
ci: add .releaserc to fix failing Release workflow

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,10 @@
+{
+  "branches": [
+    "main"
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
The `Release` workflow (`release.yaml` → reusable `create-release.yaml`) runs `npx semantic-release` with **no config passed**. With no `.releaserc` in the repo, semantic-release falls back to its **default** plugin set, which includes `@semantic-release/npm`. Its `verifyConditions` step requires a `package.json`, so on this Go module (no `package.json`) it fails:

```
SemanticReleaseError: Missing `package.json` file.
```

This fails the Release workflow on **every push to `main`** (most recently the run after #58). Because `Release` (semantic-release) is what creates the `v*` tags that `cd.yaml` (GoReleaser) builds on, releases are blocked at the first stage.

## Fix
Add the same `.releaserc` that **`dotnet-template`** already uses. It has an **identical release setup** (`create-release.yaml` on push to `main`) and releases successfully. The config scopes plugins to `commit-analyzer` + `release-notes-generator` + `github` — i.e. **no** `@semantic-release/npm`, so no `package.json` is required.

## Validation
- `.releaserc` is valid JSON and **semantically identical** to `dotnet-template`'s working config.
- Config-only change — no Go sources touched, so `go build` / `go test` / lint are unaffected.

Opened as a **draft** per the maintenance contract — promote to "ready" (or merge) to give the go-signal.
