### PR TITLE
fix(release): let GoReleaser own the GitHub release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,8 +3,6 @@
     "main"
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
+    "@semantic-release/commit-analyzer"
   ]
 }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
`CD - Go` (GoReleaser) has failed on every tag since [#59](https://github.com/devantler-tech/go-template/pull/59). Latest run on `v1.0.0` ([run](https://github.com/devantler-tech/go-template/actions/runs/26370674526)):

```
✗ upload failed  error=POST .../releases/328564694/assets?name=go-template_1.0.0_darwin_arm64.tar.gz:
  422 Cannot upload assets to an immutable release
⨯ release failed after 20s  error=scm releases: failed to publish artifacts
```

## Root cause
#59 added `.releaserc` by copying it **verbatim from `dotnet-template`**, which includes `@semantic-release/github`. That plugin creates a GitHub Release for each new tag, and GitHub now makes published releases **immutable**. The sequence is:

1. `Release` (semantic-release) pushes the tag **and** creates the immutable GitHub Release (empty — semantic-release attaches no binaries).
2. `CD - Go` fires on the tag, GoReleaser builds the binaries and tries to upload them to that release → **422, immutable**.

For `dotnet-template` the copied config is correct (it's .NET — no GoReleaser, so semantic-release rightly owns the release). A **Go** repo additionally runs GoReleaser, which must own the release to publish assets atomically.

## Fix
Mirror **ksail**'s proven `.releaserc` (a Go CLI with the identical `Release` + GoReleaser `CD` pair, releasing green):

```diff
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
+    "@semantic-release/commit-analyzer"
   ]
```

semantic-release now only computes the version and creates the tag; **GoReleaser owns the GitHub Release and its assets** (no conflict). The resulting file is byte-identical to ksail's `.releaserc`.

## Validation
- JSON validated; identical to ksail's working config.
- End-to-end: merging this `fix:` PR will itself trigger `commit-analyzer` → a patch release (`v1.0.1`), which GoReleaser will publish cleanly — confirming the fix on merge.

## Note for the maintainer
The pre-existing `v1.0.0` GitHub Release (created empty + immutable by the old config) can't be repaired in place. It's harmless to leave; the next release (`v1.0.1`) will be created correctly by GoReleaser with binaries. Delete `v1.0.0` if you'd prefer a clean release list.