### PR TITLE
fix(ci): grant contents:read so the TODOs workflow can start

### DIFF
--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -1,6 +1,7 @@
 ---
 name: "TODOs"
 permissions:
+  contents: read
   issues: write
 on:
   workflow_dispatch:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
The `TODOs` workflow `startup_failure`s on **every push to `main`** (zero jobs ever start), so the TODO-scanner has been non-functional on this repo. It is part of a portfolio-wide pattern: the same `startup_failure` hits `platform`, `go-template`, `dotnet-template`, `monorepo`, and `homebrew-tap` — but **not `ksail`**.

## Root cause
`todos.yaml` calls the reusable workflow `devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@v3.1.4`, whose job declares:

```yaml
permissions:
  contents: read
  issues: write
```

A caller's top-level `permissions:` block **caps** the permissions available to a called reusable workflow, and specifying *any* permission implicitly sets every unspecified one to `none`. This caller granted only `issues: write` (platform: `{}`), so `contents` was capped to `none`. The reusable job requests `contents: read`, which exceeds the grant → GitHub rejects the call **at startup** → `startup_failure` with no jobs. `ksail` does not fail because its caller already grants `contents: read` + `issues: write`.

## Fix
Grant `contents: read` (alongside `issues: write`) in the caller's top-level `permissions:`, matching ksail's proven-working `todos.yaml`. One-line, behaviour-preserving for everything except the broken scanner, which can now start.

## Validation
Mirrors the ksail caller that runs green; confirmed on the next push to `main` (the workflow's trigger). Same one-line fix is being applied across all affected repos.
