### PR TITLE
docs: remove Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Go Template
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![codecov](https://codecov.io/gh/devantler-tech/go-template/graph/badge.svg?token=RhQPb4fE7z)](https://codecov.io/gh/devantler-tech/go-template)
 [![Go Report Card](https://goreportcard.com/badge/github.com/devantler-tech/go-template)](https://goreportcard.com/report/github.com/devantler-tech/go-template)
 [![Go Reference](https://pkg.go.dev/badge/github.com/devantler-tech/go-template.svg)](https://pkg.go.dev/github.com/devantler-tech/go-template)
 


### PR DESCRIPTION
Coverage is now reported via GitHub Code Quality (native PR coverage) rather than Codecov, so the Codecov badge is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)