### PR TITLE
chore: remove Codecov config

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,0 @@
-ignore:
-  - "**/mocks.go"
-  - "**/testutils/**"


### PR DESCRIPTION
Coverage is now via GitHub Code Quality; the Codecov app and org token are removed, so this dead `.github/codecov.yml` is no longer used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)