### PR TITLE
fix(ci): install the release Go toolchain from go.mod

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -24,7 +24,10 @@ jobs:
       - name: ⚙️ Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.1"
+          # Track the go.mod floor so the release toolchain never drifts below it
+          # (setup-go pins GOTOOLCHAIN=local for an explicit go-version, which then
+          # fails GoReleaser when go.mod requires a newer Go than was hardcoded).
+          go-version-file: go.mod
           # Disable module cache restoration in release workflows to avoid
           # cache-poisoning risk for runtime artifacts (see https://docs.zizmor.sh/audits/#cache-poisoning)
           cache: false


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
The `CD - Go` release pipeline has been failing since the go.mod floor was bumped. The GoReleaser job in `.github/workflows/cd.yaml` hardcoded `go-version: "1.25.1"`, but [#63](https://github.com/devantler-tech/go-template/pull/63) raised the `go.mod` floor to `go 1.25.10` (needed for `deadcode@v0.43.0`). `actions/setup-go` pins `GOTOOLCHAIN=local` when given an explicit `go-version`, so GoReleaser bailed immediately at *"getting and validating git state"*:

```
release failed after 0s
  │ failed to get module path: exit status 1: go: go.mod requires go >= 1.25.10 (running go 1.25.1; GOTOOLCHAIN=local)
```

As a result the **`v1.0.2` and `v1.0.3` tag releases never published** ([run 26451728699](https://github.com/devantler-tech/go-template/actions/runs/26451728699), [run 26451227121](https://github.com/devantler-tech/go-template/actions/runs/26451227121)). `main` CI stayed green throughout because CI installs Go via the reusable `validate-go-project` workflow's `go-version-file: go.mod` — only this local CD workflow drifted.

## Fix
Read the release Go version from `go.mod` (`go-version-file: go.mod`) instead of a hardcoded string, mirroring what CI already does. The release toolchain now tracks the floor automatically and can't silently drift below it again on the next bump.

## Validation
- `actionlint .github/workflows/cd.yaml` — clean.
- Behaviour-preserving otherwise: `cache: false` (cache-poisoning guard) is unchanged; no new dependency; no caller-interface change.

## Notes
Holistic follow-up (not in this PR): other Go products with a GoReleaser CD that hardcode `go-version` would hit the same wall once their `go.mod` floor moves past the pin — worth a consistency sweep (e.g. ksail). Tracked in the run report.