### PR TITLE
feat: ship a minimal tested example package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A minimal, batteries-included Go template for new projects. Skip the boilerplate
 
 ## ✨ What's included
 
-- **Idiomatic scaffold** — a no-op `main.go` plus the conventional `cmd/`, `internal/`, and `pkg/` layout, ready for your first package.
+- **Idiomatic scaffold** — a no-op `main.go` plus the conventional `cmd/`, `internal/`, and `pkg/` layout, ready for your first package. A minimal [`pkg/example`](pkg/example) package with a table-driven test shows the house testing pattern — replace it with your own.
 - **Linting & formatting** — [`golangci-lint`](https://golangci-lint.run/) v2 (formatters + `default: all` linters) in CI, with [MegaLinter](https://megalinter.io/) covering everything else. A [pre-commit](https://pre-commit.com/) hook runs `golangci-lint` formatting (and `mockery` mock generation) locally on commit.
 - **CI/CD** — a required-checks workflow on pull requests and the merge queue, plus a [GoReleaser](https://goreleaser.com/) release pipeline (`cd.yaml`) triggered on `v*` tags.
 - **Coverage** — `go test` coverage reported via [GitHub Code Quality](https://docs.github.com/code-security/code-quality).

--- a/pkg/example/example.go
+++ b/pkg/example/example.go
@@ -1,0 +1,17 @@
+// Package example is a minimal, replaceable sample package.
+//
+// It exists so the template ships one real, tested unit out of the box: a
+// newcomer can see the house layout (a package under pkg/ with its test
+// alongside) and the table-driven test style. Delete this package and its
+// test when you add your own first package.
+package example
+
+import "fmt"
+
+// Greet returns a friendly greeting for the given name.
+//
+// It is deliberately trivial placeholder behaviour — replace it with your own
+// package's logic.
+func Greet(name string) string {
+	return fmt.Sprintf("Hello, %s!", name)
+}

--- a/pkg/example/example_test.go
+++ b/pkg/example/example_test.go
@@ -1,0 +1,31 @@
+package example_test
+
+import (
+	"testing"
+
+	"github.com/devantler-tech/go-template/pkg/example"
+)
+
+func TestGreet(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "named", input: "World", want: "Hello, World!"},
+		{name: "empty", input: "", want: "Hello, !"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := example.Greet(testCase.input)
+			if got != testCase.want {
+				t.Errorf("Greet(%q) = %q, want %q", testCase.input, got, testCase.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Closes #69 (part of the go-template roadmap #67 — template-parity lens).

## Problem
The scaffold shipped **no tests at all** (`go.sum` empty, zero `*_test.go`) and `main.go` is a no-op. So the template never demonstrated that its own test/coverage tooling works, and a project created from it inherited no testing pattern. The sibling **dotnet-template** already ships `src/Example/ExampleClass.cs` + a test for exactly this — go-template lacked the Go equivalent.

## Change
- **`pkg/example/example.go`** — a single trivial exported `Greet(name string) string` with a package + function doc comment that explicitly frames it as a replaceable placeholder. Stdlib only (`fmt`), so depguard's strict stdlib-only rule passes and **`go.sum` stays empty**.
- **`pkg/example/example_test.go`** — a black-box (`example_test` package), table-driven, parallel test asserting real behaviour (non-vacuous).
- **`README.md`** — one line under *Idiomatic scaffold* pointing newcomers at `pkg/example` as the starting pattern to replace.

Kept minimal and obviously deletable — a "replace me" example, not product code (per the template's *don't add product features* bias). `pkg/.gitkeep` is retained so deleting the example leaves the conventional empty `pkg/` intact.

## Validation (local, the repo's documented commands)
- `go build ./...` — OK
- `go test ./...` — `pkg/example` runs one real passing test (`ok … 0.440s`); root pkg still `[no test files]`
- `golangci-lint run` — **0 issues** under the repo's `default: all` config
- `golangci-lint fmt` — no changes (already formatted)
- `go mod tidy` — `go.sum` stays empty (no new deps)

## Acceptance criteria (#69)
- [x] `go test ./...` runs at least one real, passing test (non-vacuous assertion)
- [x] `go.sum` reflects deps actually used — stdlib `testing`/`fmt` only, stays empty
- [x] `golangci-lint run` (and mega-linter) stay green on the new files
- [x] Example is obviously a placeholder to replace (doc comment + README note)
- [x] Layout/style consistent with house conventions; loosely mirrors dotnet-template's `Example`