### PR TITLE
ci(deps): bring reusable-workflow pins current (v3.1.4 → v5.3.0)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,6 @@ permissions:
 
 jobs:
   release:
-    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@26f77bf515895dc8b750130ea4625a9fd8648c9c # v3.1.4
+    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@a84d9c0fe8ed4be505fb8665e94f7e9fa9c5114a # v5.3.0
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   todos:
-    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@26f77bf515895dc8b750130ea4625a9fd8648c9c # v3.1.4
+    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@a84d9c0fe8ed4be505fb8665e94f7e9fa9c5114a # v5.3.0
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #77 (child of the refreshed roadmap #75).

## Problem

`release.yaml` (`create-release`) and `todos.yaml` (`scan-for-todo-comments`) pinned `devantler-tech/reusable-workflows` at **v3.1.4** (`26f77bf5…`), **two major versions** behind the suite-wide **v5.3.0** (`a84d9c0f…`). A template should ship current, suite-aligned pins so a newly-generated project starts on the latest house workflows.

## Change

Bump both pins to **v5.3.0** (`a84d9c0fe8ed4be505fb8665e94f7e9fa9c5114a`). No caller-body changes were needed:

| workflow | v5.3.0 `workflow_call` interface | go-template caller |
|---|---|---|
| `create-release.yaml` | `secrets.APP_PRIVATE_KEY` *(required)* · `inputs.dry-run` *(optional, default false)* | passes `APP_PRIVATE_KEY` ✓ |
| `scan-for-todo-comments.yaml` | `secrets.APP_PRIVATE_KEY` *(required)* · `inputs.dry-run` *(optional, default false)* | passes `APP_PRIVATE_KEY` ✓ |

The v5 interface is **backward-compatible** with the existing callers (the new `dry-run` input is optional and unused), so this is a pure currency bump.

## Validation

- `actionlint` on both files — **clean**.
- Diff is two one-line pin changes; secrets blocks unchanged.

Docs-free (no behaviour/flags/UX change). Draft — promote to merge.