### PR TITLE
Add a minimal .editorconfig for cross-editor consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+
+[*.{yml,yaml,json,md}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
## Summary

Adds a minimal `.editorconfig` file to provide consistent editor behavior across environments.

## Changes

* UTF-8 charset
* LF line endings
* Final newline insertion
* Trailing whitespace trimming
* Tab indentation for Go files
* 2-space indentation for YAML, JSON, and Markdown files

Fixes #78
