### PR TITLE
chore: add root editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+
+[*.{yml,yaml,json,md}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Summary

Adds a minimal root `.editorconfig` for cross-editor consistency in generated projects.

## What changed

- added a root `.editorconfig`
- set UTF-8, LF endings, final newline insertion, and trailing-whitespace trimming globally
- kept Go files tab-indented to stay aligned with `gofmt`
- set 2-space indentation for YAML, JSON, and Markdown

## Why

Issue #78 asks the template to ship an editor-agnostic baseline so new repositories inherit sane defaults from the first commit without conflicting with existing Go formatting tools.

## Validation

Unable to run the repository's recommended local validation in this environment because `go` and `golangci-lint` are not installed here.
