### PR TITLE
fix: add missing run-mockery.sh for the pre-commit mockery hook

### DIFF
--- a/.github/scripts/run-mockery.sh
+++ b/.github/scripts/run-mockery.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook helper: regenerate mocks with mockery.
+#
+# The scaffold ships no interfaces and no mockery config, so there is nothing to
+# generate yet. This script therefore no-ops until the project adds a
+# `.mockery.yml`/`.mockery.yaml`, keeping the pre-commit hook green on a fresh
+# clone while wiring the (mockery) generation step the README advertises.
+set -euo pipefail
+
+# Nothing to generate until a mockery config exists.
+if [[ ! -f .mockery.yml && ! -f .mockery.yaml ]]; then
+  exit 0
+fi
+
+# mockery is installed via `go install github.com/vektra/mockery/v3@v3.5.4`
+# (see .github/workflows/copilot-setup-steps.yml).
+if ! command -v mockery >/dev/null 2>&1; then
+  echo "error: mockery not found on PATH." >&2
+  echo "Install it with: go install github.com/vektra/mockery/v3@v3.5.4" >&2
+  exit 1
+fi
+
+exec mockery

--- a/.github/scripts/run-mockery.sh
+++ b/.github/scripts/run-mockery.sh
@@ -10,15 +10,15 @@ set -euo pipefail
 
 # Nothing to generate until a mockery config exists.
 if [[ ! -f .mockery.yml && ! -f .mockery.yaml ]]; then
-  exit 0
+	exit 0
 fi
 
 # mockery is installed via `go install github.com/vektra/mockery/v3@v3.5.4`
 # (see .github/workflows/copilot-setup-steps.yml).
 if ! command -v mockery >/dev/null 2>&1; then
-  echo "error: mockery not found on PATH." >&2
-  echo "Install it with: go install github.com/vektra/mockery/v3@v3.5.4" >&2
-  exit 1
+	echo "error: mockery not found on PATH." >&2
+	echo "Install it with: go install github.com/vektra/mockery/v3@v3.5.4" >&2
+	exit 1
 fi
 
 exec mockery


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`.pre-commit-config.yaml` wires a local `mockery` hook that runs
`.github/scripts/run-mockery.sh`:

```yaml
  - repo: local
    hooks:
      - id: mockery
        name: Generate mocks with mockery
        entry: .github/scripts/run-mockery.sh
        language: script
        files: '\.go$'
        pass_filenames: false
```

…but that script does not exist (`.github/scripts/` is absent). With
`language: script`, pre-commit executes the entry directly, so **every commit
that touches a `.go` file fails** the hook on a fresh clone of the scaffold —
and the README advertises this very feature: *"A pre-commit hook runs
`golangci-lint` formatting (and `mockery` mock generation) locally on commit."*
Because this is a template, the broken hook propagates to every project
scaffolded from it.

mockery is clearly intended: `.github/workflows/copilot-setup-steps.yml`
installs it (`go install github.com/vektra/mockery/v3@v3.5.4`). The fix is to
supply the missing script, not to remove the hook.

## Fix

Add `.github/scripts/run-mockery.sh` (executable, `100755`). It is written to be
**template-friendly**:

- The scaffold ships an empty, idiomatic layout — no interfaces and no mockery
  config — so there is nothing to generate yet. The script **no-ops (exit 0)
  until a `.mockery.yml`/`.mockery.yaml` exists**, keeping the pre-commit hook
  green on a fresh clone.
- Once a consumer adds a mockery config, it runs `mockery` (resolved from
  `PATH`, matching the `go install …/mockery/v3@v3.5.4` the Copilot setup
  workflow performs). If a config is present but mockery is not installed, it
  exits non-zero with a clear install hint rather than silently skipping
  (stale-mock safety).

No behaviour change for the empty scaffold beyond *unbreaking* the hook;
`golangci-lint-fmt` is untouched.

## Validation

- `shellcheck .github/scripts/run-mockery.sh` → clean.
- No config (template state) → `exit 0`. ✓
- Config present, mockery absent → `exit 1` with install hint. ✓
- Executable bit committed (`git ls-files -s` → `100755`).
- No Go sources changed (`go build`/`go test` unaffected).

## Trade-offs / alternatives considered

- **Removing** the mockery hook + README claim instead — rejected: the Copilot
  setup workflow installs mockery, so the feature is intended; removing it would
  drop advertised functionality.
- **Shipping a `.mockery.yml`** — out of scope: the scaffold has no interfaces
  to mock, and ksail's config enumerates project-specific packages (not
  portable). Generating mock config belongs to the consumer, hence the
  no-op-until-configured design.