### PR TITLE
ci: source the Go version from go.mod in copilot-setup-steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.1"
+          # Track go.mod so the Copilot toolchain never drifts from the module floor.
+          go-version-file: go.mod
           cache: true
 
       - name: Set up Docker


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`.github/workflows/copilot-setup-steps.yml` hardcodes the Go toolchain:

```yaml
      - name: Set up Go
        uses: actions/setup-go@… # v6.4.0
        with:
          go-version: "1.25.1"
```

…but `go.mod` declares `go 1.25.10`, so the Copilot setup environment runs an
**older** Go than the module floor. AGENTS.md is explicit that `go.mod` is "the
single source of truth, so it never drifts" — yet this workflow has drifted
(1.25.1 < 1.25.10), and as a template the stale pin propagates to every
scaffolded project's Copilot environment.

`cd.yaml` already does this correctly and documents exactly why:

```yaml
          # Track the go.mod floor so the release toolchain never drifts below it
          go-version-file: go.mod
```

## Fix

Use `go-version-file: go.mod` in `copilot-setup-steps.yml`, matching `cd.yaml`.
The Copilot toolchain now tracks the module floor automatically and can never
drift again. One-line change (plus a short comment).

## Validation

- `actionlint .github/workflows/copilot-setup-steps.yml` → clean.
- `go-version-file` is supported by `actions/setup-go` v6 (already relied on in
  `cd.yaml`).