### PR TITLE
ci: pin golangci-lint to v2.5.0 in copilot-setup-steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -44,7 +44,10 @@ jobs:
           node-version: "22"
 
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$HOME/go/bin" latest
+        # Pin both the installer ref and the version to the tag used in .pre-commit-config.yaml so the
+        # Copilot toolchain lints with the same golangci-lint as local/CI, and never resolves to an
+        # unpinned `latest` whose tarball checksum can break the install (e.g. the v2.12.2 mismatch).
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.5.0/install.sh | sh -s -- -b "$HOME/go/bin" v2.5.0
 
       - name: Install mega-linter-runner
         run: npm install mega-linter-runner -g


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The **Copilot Setup Steps** workflow is red on `main` (recurring — observed 2026-05-29 and 2026-06-07). The `Install golangci-lint` step:

```yaml
run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$HOME/go/bin" latest
```

is unpinned on **both** axes — installer from `master`, version `latest`. `latest` now resolves to golangci-lint **v2.12.2**, whose published tarball fails the installer's SHA-256 checksum verification:

```
golangci/golangci-lint err hash_sha256_verify checksum for '…/golangci-lint-2.12.2-linux-amd64.tar.gz' did not verify
  fd3a137c…  vs  8df580d2…
##[error]Process completed with exit code 1.
```

## Fix

Pin both the installer ref and the installed version to **v2.5.0** — the tag already used in [`.pre-commit-config.yaml`](.pre-commit-config.yaml):

```yaml
run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.5.0/install.sh | sh -s -- -b "$HOME/go/bin" v2.5.0
```

Benefits:
- The installer-at-tag verifies a checksum from the **same release** as the version it installs (consistent by construction), so it can't break on a bad `latest` tarball.
- The Copilot toolchain now lints with the **same golangci-lint version as local/pre-commit and CI** (v2.5.0), eliminating drift.
- Matches the repo's universal pinning convention (and the `go install …@v3.5.4` Mockery step right below it).

When the repo bumps golangci-lint, bump this alongside `.pre-commit-config.yaml`'s `rev` so they stay in lockstep.

## Validation

- `actionlint` clean on the modified workflow.
- The pinned installer URL (`…/golangci-lint/v2.5.0/install.sh`) resolves (HTTP 200); v2.5.0 is a real release already used by the repo.
- This workflow triggers on changes to itself (`paths: .github/workflows/copilot-setup-steps.yml`), so **this PR's own CI run is the end-to-end proof** the install now succeeds green.

Operate work (red-on-main fix). Template consumers who use the GitHub Copilot coding agent inherit this setup, so keeping it green benefits them too.