### PR TITLE
docs: fix Run-your-project command to match the shipped scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ go build ./...
 ### Run your project
 
 ```bash
-go run ./<project>
+go run .
 ```
 
 ### Test your project


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The README **Usage → Run your project** step documents a command that **fails on the as-shipped template**:

```bash
go run ./<project>
```

There is no `<project>` directory in the scaffold — `cmd/`, `internal/`, and `pkg/` ship as empty `.gitkeep` placeholders, and the runnable entry point is the root `main.go` (`package main`). So the documented command errors for any user, with or without substituting a name:

```
$ go run ./<project>
stat .../<project>: directory not found      # exit 1
$ go run ./project
stat .../project: directory not found        # exit 1
```

## Fix

Document the command that actually runs the shipped scaffold out of the box:

```bash
go run .          # runs the root main.go → exit 0
```

This is consistent with the whole-module forms already documented in the same Usage section (`go build ./...`, `go test ./...`) and with the "works from a clean baseline" spirit of the template. A user who later moves their entry point under `cmd/<name>/` will naturally adjust to `go run ./cmd/<name>`.

## Validation

Verified against a fresh clone on `go1.26.4`:

| command | result |
|---|---|
| `go run .` | **exit 0** ✅ |
| `go run ./<project>` (as written) | exit 1 — `directory not found` |
| `go run ./project` (placeholder substituted) | exit 1 — `directory not found` |

Docs-only, single-line change; `AGENTS.md` and the rest of the README were reviewed and are accurate (no further drift).