### PR TITLE
docs: correct AGENTS.md CI-validation claim (ruleset injects validate-go-project)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ need.
 
 ## Validation
 
-Recommended local validation before opening a PR (CI runs only a required-checks aggregator and the release pipeline runs GoReleaser, so neither executes these commands — run them locally):
+Run these locally before opening a PR:
 
 ```bash
 golangci-lint fmt        # apply configured formatters (gci, gofmt, gofumpt, goimports, golines, swaggo)
@@ -34,6 +34,16 @@ golangci-lint run        # run the configured linters
 ```
 
 Workflow YAML changes should pass `actionlint`.
+
+These local checks are for fast feedback — **CI does verify the scaffold.** A
+**repository ruleset** ("Require workflows to pass before merging for Go")
+injects the shared `devantler-tech/reusable-workflows` **`validate-go-project`**
+workflow on every PR and the merge queue; it runs `go build`, `go test`,
+`golangci-lint`, dead-code analysis, MegaLinter, and Code-Quality coverage
+(change-detection skips the Go jobs on non-Go PRs). The repo's own `ci.yaml` is
+a separate, trivially-passing `CI - Required Checks` aggregator — **not** the Go
+gate — so do **not** wire `validate-go-project` into `ci.yaml`; that would
+double-run every job (see go-template#76, closed as invalid).
 
 ## Maintenance (autonomous AI assistant)
 
@@ -54,7 +64,7 @@ Assistant`. This section adds go-template-specifics. As a project template, the
 bias is to keep the scaffold **minimal, idiomatic, and current** — don't add
 product features.
 
-**Validate before any PR (locally):** `golangci-lint fmt` (if configured), `go build ./... && go test ./...`, `golangci-lint run` — recommended local checks; CI itself only runs a required-checks aggregator, so run these yourself before opening a PR. Workflows → `actionlint`.
+**Validate before any PR (locally):** `golangci-lint fmt` (if configured), `go build ./... && go test ./...`, `golangci-lint run` — local checks for fast feedback (the ruleset-injected `validate-go-project` workflow re-runs build/test/lint/coverage on the PR — see *Validation* above; don't duplicate it into `ci.yaml`). Workflows → `actionlint`.
 
 **Task menu** (light; ≤1 high-value item per run):
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`AGENTS.md` twice claimed CI does **not** verify the scaffold:

- *Validation* section: *"…CI runs only a required-checks aggregator and the release pipeline runs GoReleaser, so neither executes these commands — run them locally"*
- *Maintenance* section: *"…CI itself only runs a required-checks aggregator, so run these yourself before opening a PR."*

Both are **inaccurate**. CI genuinely builds/tests/lints the scaffold — and this exact wrong premise is what lured a prior run into filing **#76** (*"wire the shared validate-go-project workflow so CI actually verifies the scaffold"*), which was **closed as invalid**: wiring it into `ci.yaml` would double-run every job because the workflow already runs via a repository ruleset.

## Ground truth (verified live, 2026-06-09)

A repository ruleset **"Require workflows to pass before merging for Go"** (active) injects `devantler-tech/reusable-workflows/.github/workflows/validate-go-project.yaml@main` on every PR + merge queue. On PR #98 the `✅ Validate Go Project` workflow ran (`🔍 Detect Changes`, `🧹 Lint - mega-linter` = SUCCESS; `🏗️ Build`/`🧪 Test`/`golangci-lint`/`Dead Code`/`Coverage` SKIPPED only because #98 was an actions-only bump — change-detection correctly gates the Go jobs to Go-touching PRs). The repo's own `ci.yaml` `CI - Required Checks` aggregator (empty `job-results`) is a *separate, trivially-passing* status check — **not** the Go gate.

So the README (which advertises golangci-lint/MegaLinter/coverage "in CI") was right all along; only `AGENTS.md` contradicted reality.

## Fix (docs-only, AGENTS.md only)

- *Validation*: drop the false "CI runs only an aggregator" parenthetical; add a paragraph stating CI **does** verify the scaffold via the ruleset-injected `validate-go-project` (build/test/golangci-lint/dead-code/MegaLinter/coverage), that `ci.yaml` is a separate trivially-passing aggregator, and an explicit **don't wire `validate-go-project` into `ci.yaml` (double-run; see #76 closed-invalid)** note.
- *Maintenance → Validate before any PR*: reframe the local commands as fast-feedback (not "because CI skips them") and cross-reference the *Validation* note.

No `ci.yaml`/workflow change — this PR only makes the agent file match live CI, so a future agent reading it won't re-derive the #76 misstep.

## Why it matters

Agent/instruction files are a maintained product: a wrong one silently misleads every future agent and reviewer. This is a recurring trap (the #76 re-proposal premise) closed at the source.

**Size:** XS (docs-only).