### PR TITLE
feat(scripts): add rename-placeholders.sh for one-shot module-path onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ need.
 - `.golangci.yml` — golangci-lint v2 config (formatters + `default: all` linters, with a few opt-outs and mock-file exclusions).
 - `.github/workflows/` — `ci.yaml` (required-checks aggregation on PRs/merge queue), `cd.yaml` (GoReleaser release on `v*` tags), `release.yaml`, `sync-labels.yaml`, `todos.yaml`, and `copilot-setup-steps.yml`.
 - `.pre-commit-config.yaml`, `.mega-linter.yml`, `cspell.json` — local linting/spell-checking configuration.
+- `scripts/rename-placeholders.sh` — one-shot onboarding: repoints the module path (`go.mod`, Go imports, README badges) to a new project's path, leaving the upstream **Use this template** links intact.
 
 ## Validation
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,17 @@ cd my-project
 
 Or click **Use this template** on the [repository page](https://github.com/devantler-tech/go-template).
 
-Then point the module at your own path:
+Then personalise the scaffold — repoint the module path (in `go.mod`, the Go
+imports, and the README badges) in one shot:
 
 ```bash
-go mod edit -module github.com/<you>/my-project
-go mod tidy
+scripts/rename-placeholders.sh github.com/<you>/my-project
 ```
+
+Run with no argument to derive the path from your `origin` GitHub remote. The
+script leaves the upstream **Use this template** links above untouched, runs
+`go mod tidy`, and you can review the result with `git diff`. (Prefer to do it
+by hand? `go mod edit -module github.com/<you>/my-project && go mod tidy`.)
 
 ## 📝 Usage
 

--- a/scripts/rename-placeholders.sh
+++ b/scripts/rename-placeholders.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env sh
+# rename-placeholders.sh — turn this scaffold into your own module in one shot.
+#
+# Fresh from `Use this template`, the project still carries the template's module
+# path `github.com/devantler-tech/go-template`. It appears in three kinds of place:
+#   • go.mod          — the `module` line.
+#   • *.go            — import paths (e.g. pkg/example's test imports the module).
+#   • README.md       — the Go Report Card / pkg.go.dev *badge* URLs.
+# Doing this by hand is easy to get half-wrong, so this script repoints all three
+# WITHOUT touching the references that MUST keep pointing at the upstream template:
+#   • README's "Use this template" links (`--template devantler-tech/go-template`
+#     and the `[repository page]` link) — those describe where the template lives.
+#
+# Usage:  scripts/rename-placeholders.sh [module-path]
+#   e.g.  scripts/rename-placeholders.sh github.com/acme/widget
+# With no argument it derives the path from origin's GitHub remote.
+set -eu
+
+OLD_MODULE="github.com/devantler-tech/go-template"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+new_module="${1:-}"
+if [ -z "$new_module" ]; then
+  remote="$(git -C "$repo_root" remote get-url origin 2>/dev/null || true)"
+  case "$remote" in
+    *github.com[:/]*)
+      path="${remote#*github.com}"   # strip up to and incl. github.com
+      path="${path#:}"               # scp-style  git@github.com:owner/repo
+      path="${path#/}"               # https      .../owner/repo
+      path="${path%.git}"
+      [ -n "$path" ] && new_module="github.com/$path"
+      ;;
+  esac
+fi
+
+if [ -z "$new_module" ]; then
+  echo "usage: scripts/rename-placeholders.sh <module-path>" >&2
+  echo "       e.g. scripts/rename-placeholders.sh github.com/acme/widget" >&2
+  echo "       (could not derive it from origin's GitHub remote)." >&2
+  exit 1
+fi
+
+if [ "$new_module" = "$OLD_MODULE" ]; then
+  echo "error: the new module path equals the template's own ($OLD_MODULE)." >&2
+  echo "       run this in a project created from the template, with your own path." >&2
+  exit 1
+fi
+
+# A Go module path is host(/segment)+ — reject anything that obviously is not one.
+if ! printf '%s' "$new_module" | grep -Eq '^[A-Za-z0-9._~-]+(/[A-Za-z0-9._~-]+)+$'; then
+  echo "error: '$new_module' does not look like a module path (host/owner/name)." >&2
+  exit 1
+fi
+
+changed=0
+
+# 1) Code: go.mod + every tracked .go file — repoint the module path everywhere.
+code_files="$(git -C "$repo_root" grep -lF "$OLD_MODULE" -- '*.go' 'go.mod' 2>/dev/null || true)"
+# 2) README badges only: restrict the substitution to badge-service lines so the
+#    "Use this template" upstream links are left intact.
+readme_files="$(git -C "$repo_root" grep -lF "$OLD_MODULE" -- 'README.md' 2>/dev/null || true)"
+
+for f in $code_files; do
+  abs="$repo_root/$f"
+  tmp="$abs.rename.$$"
+  sed "s|$OLD_MODULE|$new_module|g" "$abs" > "$tmp"
+  if cmp -s "$abs" "$tmp"; then rm -f "$tmp"; else mv "$tmp" "$abs"; changed=$((changed + 1)); fi
+done
+
+for f in $readme_files; do
+  abs="$repo_root/$f"
+  tmp="$abs.rename.$$"
+  # One address per service — BSD sed (macOS) has no GNU `\|` alternation.
+  sed \
+    -e "/goreportcard\.com/ s|$OLD_MODULE|$new_module|g" \
+    -e "/pkg\.go\.dev/ s|$OLD_MODULE|$new_module|g" \
+    "$abs" > "$tmp"
+  if cmp -s "$abs" "$tmp"; then rm -f "$tmp"; else mv "$tmp" "$abs"; changed=$((changed + 1)); fi
+done
+
+# Normalise go.mod/go.sum if the Go toolchain is available (no-op for a pure rename).
+if command -v go >/dev/null 2>&1; then
+  ( cd "$repo_root" && go mod tidy )
+fi
+
+echo "renamed $OLD_MODULE -> $new_module across $changed file(s)."
+echo "next: review 'git diff', then 'go build ./... && go test ./...'."

--- a/scripts/rename-placeholders.sh
+++ b/scripts/rename-placeholders.sh
@@ -22,35 +22,35 @@ repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 new_module="${1:-}"
 if [ -z "$new_module" ]; then
-  remote="$(git -C "$repo_root" remote get-url origin 2>/dev/null || true)"
-  case "$remote" in
-    *github.com[:/]*)
-      path="${remote#*github.com}"   # strip up to and incl. github.com
-      path="${path#:}"               # scp-style  git@github.com:owner/repo
-      path="${path#/}"               # https      .../owner/repo
-      path="${path%.git}"
-      [ -n "$path" ] && new_module="github.com/$path"
-      ;;
-  esac
+	remote="$(git -C "$repo_root" remote get-url origin 2>/dev/null || true)"
+	case "$remote" in
+	*github.com[:/]*)
+		path="${remote#*github.com}" # strip up to and incl. github.com
+		path="${path#:}"             # scp-style  git@github.com:owner/repo
+		path="${path#/}"             # https      .../owner/repo
+		path="${path%.git}"
+		[ -n "$path" ] && new_module="github.com/$path"
+		;;
+	esac
 fi
 
 if [ -z "$new_module" ]; then
-  echo "usage: scripts/rename-placeholders.sh <module-path>" >&2
-  echo "       e.g. scripts/rename-placeholders.sh github.com/acme/widget" >&2
-  echo "       (could not derive it from origin's GitHub remote)." >&2
-  exit 1
+	echo "usage: scripts/rename-placeholders.sh <module-path>" >&2
+	echo "       e.g. scripts/rename-placeholders.sh github.com/acme/widget" >&2
+	echo "       (could not derive it from origin's GitHub remote)." >&2
+	exit 1
 fi
 
 if [ "$new_module" = "$OLD_MODULE" ]; then
-  echo "error: the new module path equals the template's own ($OLD_MODULE)." >&2
-  echo "       run this in a project created from the template, with your own path." >&2
-  exit 1
+	echo "error: the new module path equals the template's own ($OLD_MODULE)." >&2
+	echo "       run this in a project created from the template, with your own path." >&2
+	exit 1
 fi
 
 # A Go module path is host(/segment)+ — reject anything that obviously is not one.
 if ! printf '%s' "$new_module" | grep -Eq '^[A-Za-z0-9._~-]+(/[A-Za-z0-9._~-]+)+$'; then
-  echo "error: '$new_module' does not look like a module path (host/owner/name)." >&2
-  exit 1
+	echo "error: '$new_module' does not look like a module path (host/owner/name)." >&2
+	exit 1
 fi
 
 changed=0
@@ -62,26 +62,32 @@ code_files="$(git -C "$repo_root" grep -lF "$OLD_MODULE" -- '*.go' 'go.mod' 2>/d
 readme_files="$(git -C "$repo_root" grep -lF "$OLD_MODULE" -- 'README.md' 2>/dev/null || true)"
 
 for f in $code_files; do
-  abs="$repo_root/$f"
-  tmp="$abs.rename.$$"
-  sed "s|$OLD_MODULE|$new_module|g" "$abs" > "$tmp"
-  if cmp -s "$abs" "$tmp"; then rm -f "$tmp"; else mv "$tmp" "$abs"; changed=$((changed + 1)); fi
+	abs="$repo_root/$f"
+	tmp="$abs.rename.$$"
+	sed "s|$OLD_MODULE|$new_module|g" "$abs" >"$tmp"
+	if cmp -s "$abs" "$tmp"; then rm -f "$tmp"; else
+		mv "$tmp" "$abs"
+		changed=$((changed + 1))
+	fi
 done
 
 for f in $readme_files; do
-  abs="$repo_root/$f"
-  tmp="$abs.rename.$$"
-  # One address per service — BSD sed (macOS) has no GNU `\|` alternation.
-  sed \
-    -e "/goreportcard\.com/ s|$OLD_MODULE|$new_module|g" \
-    -e "/pkg\.go\.dev/ s|$OLD_MODULE|$new_module|g" \
-    "$abs" > "$tmp"
-  if cmp -s "$abs" "$tmp"; then rm -f "$tmp"; else mv "$tmp" "$abs"; changed=$((changed + 1)); fi
+	abs="$repo_root/$f"
+	tmp="$abs.rename.$$"
+	# One address per service — BSD sed (macOS) has no GNU `\|` alternation.
+	sed \
+		-e "/goreportcard\.com/ s|$OLD_MODULE|$new_module|g" \
+		-e "/pkg\.go\.dev/ s|$OLD_MODULE|$new_module|g" \
+		"$abs" >"$tmp"
+	if cmp -s "$abs" "$tmp"; then rm -f "$tmp"; else
+		mv "$tmp" "$abs"
+		changed=$((changed + 1))
+	fi
 done
 
 # Normalise go.mod/go.sum if the Go toolchain is available (no-op for a pure rename).
 if command -v go >/dev/null 2>&1; then
-  ( cd "$repo_root" && go mod tidy )
+	(cd "$repo_root" && go mod tidy)
 fi
 
 echo "renamed $OLD_MODULE -> $new_module across $changed file(s)."


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Implements #105 (part of the go-template roadmap #104, theme 1: onboarding friction).

## Problem
Fresh from `Use this template`, a project still carries the template's module path `github.com/devantler-tech/go-template` in three kinds of place — `go.mod`, the Go import paths (`pkg/example`'s test), and the README Go Report Card / pkg.go.dev **badge** URLs. The README told you to fix `go.mod` by hand (`go mod edit …`), leaving the imports and badges to hunt down — easy to get half-wrong.

## Change
Add **`scripts/rename-placeholders.sh`** — repoints the module path across all three in one shot:
- **Code** (`go.mod` + every tracked `*.go`): full module-path replace.
- **README badges only** (`goreportcard.com` / `pkg.go.dev` lines): repointed — while the upstream **Use this template** links (`--template devantler-tech/go-template` and the *repository page* link) are **deliberately left intact**, since they describe where the template lives, not your project. This is the "must-not-change" trap #105 called out.
- Runs `go mod tidy` when the Go toolchain is present (a no-op for a pure rename, but normalises).
- **Argument** = new module path; with none, derives it from `origin`'s GitHub remote (scp- or https-style).
- **Guards:** rejects a path that isn't `host/owner/name`, and refuses the template's own path (so running it un-personalised is a clear error, not a silent no-op).

README's "Use this template" section now calls the script (manual `go mod edit` kept as a one-line fallback); `AGENTS.md` repository-structure lists the new `scripts/`.

## Validation
- `shellcheck` clean; **POSIX `sh`** with `set -eu`.
- **BSD/GNU-sed portable** — the badge substitution uses one `-e` address per service rather than GNU `\|` alternation (caught in testing on macOS/BSD sed, where `\|` silently matched nothing and left badges un-renamed).
- End-to-end on a fresh copy: `scripts/rename-placeholders.sh github.com/acme/widget` rewrites go.mod + the test import + both badges, leaves the two upstream links untouched, and `go build ./... && go test ./...` stays green (3 tests pass).
- Edge cases verified: same-as-template path → rejected; non-module-path arg → rejected.

No Go source changed; the `validate-go-project` gate / build / test are unaffected.
