### PR TITLE
docs: document the Go toolchain-floor policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,18 @@ Assistant`. This section adds go-template-specifics. As a project template, the
 bias is to keep the scaffold **minimal, idiomatic, and current** — don't add
 product features.
 
+**Toolchain-floor policy.** The Go floor in `go.mod` is the **single source of
+truth** and is **tooling-driven**: it equals the **highest minimum the house
+tooling requires** — today Go 1.25, because the shared `validate-go-project`
+Dead Code Analysis step installs `deadcode` (needs Go ≥ 1.25) — *not* "latest
+Go" and *not* a language-feature choice. Bump it **only** when a shared-tooling
+requirement forces it (or a security / end-of-life reason), never
+speculatively, and **record the trigger in the PR body**. Don't over-raise:
+keeping the floor at the minimum the tooling needs keeps generated projects as
+broadly compatible as possible. Nothing else hard-codes the version — `copilot-setup-steps.yml` reads
+`go-version-file: go.mod` and the README points at `go.mod` — so keep it that
+way (no second copy to drift).
+
 **Validate before any PR (locally):** `golangci-lint fmt` (if configured), `go build ./... && go test ./...`, `golangci-lint run` — local checks for fast feedback (the ruleset-injected `validate-go-project` workflow re-runs build/test/lint/coverage on the PR — see *Validation* above; don't duplicate it into `ci.yaml`). Workflows → `actionlint`.
 
 **Task menu** (light; ≤1 high-value item per run):
@@ -73,4 +85,5 @@ product features.
 - **Dependency/toolchain hygiene:** curate Dependabot/Renovate PRs; keep the toolchain version (Go) and pinned action versions current and aligned with the house workflows; flag majors.
 - **CI/workflow health:** keep CI green and tidy (pin/align actions, fix broken/flaky steps, remove dead workflows); red on `main` is top priority.
 - **Scaffold freshness:** the generated project builds & tests on the current toolchain; README/badges accurate; example code idiomatic and minimal.
+- **Toolchain-floor freshness:** on any toolchain/tooling bump, re-confirm the `go.mod` Go floor is still *exactly* the minimum the house tooling needs — don't over-raise — and that nothing has introduced a hard-coded Go version that could drift from it (see the *Toolchain-floor policy* above).
 - **Maintain your own PRs:** fix CI you caused, resolve conflicts.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #106 (part of epic #104, theme 2 — toolchain & scaffold currency).

## Problem

The Go floor in `go.mod` (`1.25.10`) is **tooling-driven**, not a language-feature choice: it was raised from 1.24 because the shared `validate-go-project` Dead Code Analysis step installs `deadcode`, which needs Go ≥ 1.25. That rationale lived only as a one-line sentence in the project overview. Without a stated *policy*, a future bump (or a failure to bump) looks arbitrary, and "why 1.25, not latest, not 1.24" gets re-litigated each time the toolchain moves.

## Change (docs / agent-file only)

`AGENTS.md` `## Maintenance`:

- **Adds a `Toolchain-floor policy` paragraph** — the floor = the **highest minimum the house tooling requires** (today `deadcode` ⇒ 1.25), *not* "latest Go" and *not* a language-feature need; `go.mod` is the single source of truth; bump **only** when a shared-tooling requirement forces it (or a security / end-of-life reason), never speculatively, and **record the trigger in the PR body**; don't over-raise.
- **Adds a `Toolchain-floor freshness` task-menu item** — on any toolchain/tooling bump, re-confirm the floor is still exactly the minimum the tooling needs and that nothing reintroduced a hard-coded Go version that could drift from `go.mod`.

## Accuracy note

Verified live before writing: nothing in the repo hard-codes the Go version — `copilot-setup-steps.yml` reads `go-version-file: go.mod` and the README points at `go.mod`. So the policy states there is **no second copy to keep in sync**, rather than implying phantom duplicates (the generic issue text assumed badges/setup hard-code it; they don't).

## Acceptance criteria

- [x] `AGENTS.md` states the floor-selection rule + current trigger, with `go.mod` named as the source of truth.
- [x] The maintenance task menu gains a one-line toolchain-floor freshness check.
- [x] Concise, docs/agent-file only — no code change; +13 lines.

No code touched → the ruleset-injected `validate-go-project` Go jobs skip via change-detection; MegaLinter/cspell cover the prose (British spelling + acronym reworded to safe terms to keep cspell green).